### PR TITLE
[VSP-1256] Updating currency formatter to handle symbol in front or back

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-  "name": "amoreno/currency-formatter",
-  "version": "0.2.0",
+  "name": "vivastreet/currency-formatter",
+  "version": "0.3.0",
   "description": "PHP Lib for formatting currencies according to currency code",
   "type": "library",
   "license": "MIT",


### PR DESCRIPTION
Updating composer in order to rename amoreno/currency-formatter to vivastreet/currency-formatter